### PR TITLE
only configure AWS authenticator if explicitly configured

### DIFF
--- a/src/main/java/com/appdynamics/extensions/cloudwatch/AmazonCloudWatchMonitor.java
+++ b/src/main/java/com/appdynamics/extensions/cloudwatch/AmazonCloudWatchMonitor.java
@@ -179,8 +179,13 @@ public class AmazonCloudWatchMonitor extends AManagedMonitor {
     }
 
 	private void fetchAndPrintMetrics(String namespace, String region) {
-        AmazonCloudWatch awsCloudWatch = new AmazonCloudWatchClient(credentials, clientConfiguration);
-        awsCloudWatch.setEndpoint(regionVsURLs.get(region));
+        AmazonCloudWatch awsCloudWatch;
+		if (credentials == null) {
+			awsCloudWatch = new AmazonCloudWatchClient(clientConfiguration);
+		} else {
+			awsCloudWatch = new AmazonCloudWatchClient(credentials, clientConfiguration);
+		}
+		awsCloudWatch.setEndpoint(regionVsURLs.get(region));
 		MetricsManager metricsManager = metricsManagerFactory.createMetricsManager(namespace);
         metricsManager.setWorkerPool(awsMetricWorkerPool);
 		Map<String, Map<String, List<Datapoint>>> metrics = metricsManager.gatherMetrics(awsCloudWatch, region);

--- a/src/main/java/com/appdynamics/extensions/cloudwatch/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/appdynamics/extensions/cloudwatch/configuration/ConfigurationUtil.java
@@ -159,6 +159,11 @@ public class ConfigurationUtil {
 	}
 
     private static void initializeAWSCredentials(Configuration awsConfiguration, Document doc) {
+		if (doc.getElementsByTagName("AWSCredentials").item(0) == null) {
+			// not specified, use default handler chain of amazon sdk like using IAM instance profiles
+			return;
+		}
+
         Element credentialsFromFile = (Element) doc.getElementsByTagName("AWSCredentials").item(0);
         if(credentialsFromFile.getElementsByTagName("EncryptionKey").item(0) != null) {
             String encryptionKey = doc.getElementsByTagName("EncryptionKey").item(0).getTextContent();

--- a/src/main/java/com/appdynamics/extensions/cloudwatch/ec2/EC2InstanceNameManager.java
+++ b/src/main/java/com/appdynamics/extensions/cloudwatch/ec2/EC2InstanceNameManager.java
@@ -144,7 +144,12 @@ public class EC2InstanceNameManager {
 	}
 	
 	private void retrieveInstancesPerRegion(String region, String... instanceIds) {
-		AmazonEC2Client ec2Client = new AmazonEC2Client(awsCredentials);
+		AmazonEC2Client ec2Client;
+		if (awsCredentials == null) {
+			ec2Client = new AmazonEC2Client();
+		} else {
+			ec2Client = new AmazonEC2Client(awsCredentials);
+		}
 		ec2Client.setEndpoint(regionEndPoints.get(region));
 		
 		Filter filter = new Filter();


### PR DESCRIPTION
Since a while, AWS IAM provides IAM instance profiles. A way, to attach permissions to EC2 servers, so that you do not need dedicated IAM users anymore with statically configured credentials. With this patch, it is possible to strip out the secret configuration completely, and use the standard Amazon SDK discovery chain for credentials, so that you can assign permissions to your server and use this extension without hardcoded secrets.